### PR TITLE
Added 'validation' error type

### DIFF
--- a/overview/errors.md
+++ b/overview/errors.md
@@ -30,4 +30,8 @@ The response body will always be JSON and contain an Error object.
         <td>limit_reached</td>
         <td>The request was made too fast, wait and try again</td>
     </tr>
+    <tr>
+        <td>validation</td>
+        <td>One or more of the parameters didn't fulfill the validation.</td>
+    </tr>
 </table>


### PR DESCRIPTION
`POST /rooms` with a duplicated name will respond with a `400 Bad Request` and response body:

``` json
{
    "type": "validation",
    "message": "has already been taken",
    "param": "name"
}
```
