### PR TITLE
Corrected  the parameter when updating a message

### DIFF
--- a/endpoints/messages.md
+++ b/endpoints/messages.md
@@ -77,7 +77,7 @@ m.save
         <td>ID of the message to update</td>
     </tr>
     <tr>
-        <td>message</td>
+        <td>text</td>
         <td>required</td>
         <td>The new text for the message</td>
     </tr>


### PR DESCRIPTION
You need to `PUT /messages/:id` with `{"text": "whatever"}` instead of the suggested "message".

I can't confirm about the Ruby gem but probably you need to update that line too.
